### PR TITLE
Improve Youtube regex

### DIFF
--- a/src/tuneefy/Platform/Platforms/YoutubePlatform.php
+++ b/src/tuneefy/Platform/Platforms/YoutubePlatform.php
@@ -116,7 +116,8 @@ class YoutubePlatform extends Platform implements WebStreamingPlatformInterface
 
         // Check if parts[2] is something like "official video"
         if (count($parts) > 1) {
-            if (preg_match("/(?P<title>.*)[\(\[](.*official.*video.*)[\)\]]/iu", $parts[1], $matches)) {
+            // Inspired by https://github.com/tomahawk-player/tomahawk-resolvers/blob/master/youtube/content/contents/code/youtube.js#L578
+            if (preg_match("/(?P<title>[^\(^\[]*)(?:[\(\[].*?(?:offici(?:a|e)l|clip).*?(?:[\)\]])|(?:(?:offici(?:a|e)l|video)).*?(?:video|clip))/iu", $parts[1], $matches)) {
                 $title = trim($matches['title']);
 
                 return [$title, trim($parts[0])];


### PR DESCRIPTION
Improve the Youtube regex by being more permissive on "Official" titles for music videos;

Based on [Tomahawk resolver for Youtube ](https://github.com/tomahawk-player/tomahawk-resolvers/blob/master/youtube/content/contents/code/youtube.js)

Related to #2 

Isolated test code : 

```php
function testRegex($string) {
    $parts = explode(' - ', $string);
    if (count($parts) > 1) {
        if (preg_match("/(?P<title>[^\(^\[]*)(?:[\(\[].*?(?:offici(?:a|e)l|clip).*?(?:[\)\]])|(?:(?:offici(?:a|e)l|video)).*?(?:video|clip))/iu", $parts[1], $matches)) {
            echo "'" . trim($matches['title']) . "' by '" . trim($parts[0]) . "'\n";
            return true;
        }
    }
    echo "Failed for : ".$string;
}

testRegex('ARTIST - TITLE [Official Video]');
testRegex('ARTIST - TITLE (Official)');
testRegex('ARTIST - TITLE (Officiel)');
testRegex('ARTIST - TITLE (CLIP OFFICIEL)');
testRegex('ARTIST - TITLE (CLIP)');
testRegex('ARTIST - TITLE (video officielle)');
testRegex('ARTIST - TITLE (vidéo officielle)');
```